### PR TITLE
Syntactic sugar, typedefs as components, and timesteps

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,0 +1,1 @@
+--macro addGlobalMetadata("", "@:build(echoes.core.macro.AbstractEntity.build())")

--- a/src/echoes/Entity.hx
+++ b/src/echoes/Entity.hx
@@ -105,8 +105,7 @@ abstract Entity(Int) from Int to Int {
      * @return `Entity`
      */
     macro public function remove(self:Expr, types:Array<ExprOf<Class<Any>>>):ExprOf<echoes.Entity> {
-        return EntityTools.remove(self,
-            [for(type in types) type.parseClassName().getType().followMono().toComplexType()]);
+        return EntityTools.remove(self, [for(type in types) type.parseClassType()]);
     }
 
     /**
@@ -116,7 +115,7 @@ abstract Entity(Int) from Int to Int {
      * @return `T:Any` component instance
      */
     macro public function get<T>(self:Expr, type:ExprOf<Class<T>>):ExprOf<T> {
-        return EntityTools.get(self, type.parseClassName().getType().followMono().toComplexType());
+        return EntityTools.get(self, type.parseClassType());
     }
 
     /**
@@ -125,7 +124,7 @@ abstract Entity(Int) from Int to Int {
      * @return `Bool`
      */
     macro public function exists(self:Expr, type:ExprOf<Class<Any>>):ExprOf<Bool> {
-        return EntityTools.exists(self, type.parseClassName().getType().followMono().toComplexType());
+        return EntityTools.exists(self, type.parseClassType());
     }
 
 

--- a/src/echoes/Entity.hx
+++ b/src/echoes/Entity.hx
@@ -101,7 +101,7 @@ abstract Entity(Int) from Int to Int {
 
         var addComponentsToContainersExprs = components
             .map(function(c) {
-                var containerName = (c.typeof().follow().toComplexType()).getComponentContainer().followName();
+                var containerName = (MacroTools.typeof(c).followMono().toComplexType()).getComponentContainer().followName();
                 return macro @:privateAccess $i{ containerName }.inst().add(__entity__, $c);
             });
 
@@ -141,7 +141,7 @@ abstract Entity(Int) from Int to Int {
 
         var cts = types
             .map(function(type) {
-                return type.parseClassName().getType().follow().toComplexType();
+                return type.parseClassName().getType().followMono().toComplexType();
             });
 
         var removeComponentsFromContainersExprs = cts
@@ -187,7 +187,7 @@ abstract Entity(Int) from Int to Int {
      * @return `T:Any` component instance
      */
     macro public function get<T>(self:Expr, type:ExprOf<Class<T>>):ExprOf<T> {
-        var containerName = (type.parseClassName().getType().follow().toComplexType()).getComponentContainer().followName();
+        var containerName = (type.parseClassName().getType().followMono().toComplexType()).getComponentContainer().followName();
         var body = [ macro return $i{ containerName }.inst().get(__entity__) ];
 
         var ret = macro #if (haxe_ver >= 4) inline #end ( function(__entity__:echoes.Entity) $b{body} )($self);
@@ -205,7 +205,7 @@ abstract Entity(Int) from Int to Int {
      * @return `Bool`
      */
     macro public function exists(self:Expr, type:ExprOf<Class<Any>>):ExprOf<Bool> {
-        var containerName = (type.parseClassName().getType().follow().toComplexType()).getComponentContainer().followName();
+        var containerName = (type.parseClassName().getType().followMono().toComplexType()).getComponentContainer().followName();
         var body = [ macro return $i{ containerName }.inst().exists(__entity__) ];
 
         var ret = macro #if (haxe_ver >= 4) inline #end ( function(__entity__:echoes.Entity) $b{body} )($self);

--- a/src/echoes/Entity.hx
+++ b/src/echoes/Entity.hx
@@ -1,6 +1,7 @@
 package echoes;
 
 #if macro
+import echoes.core.macro.EntityTools;
 import haxe.macro.Expr;
 using echoes.core.macro.ComponentBuilder;
 using echoes.core.macro.ViewsOfComponentBuilder;
@@ -103,34 +104,7 @@ abstract Entity(Int) from Int to Int {
      * @return `Entity`
      */
     macro public function add(self:Expr, components:Array<ExprOf<Any>>):ExprOf<echoes.Entity> {
-        if (components.length == 0) {
-            Context.error('Required one or more Components', Context.currentPos());
-        }
-
-        var addComponentsToContainersExprs = components
-            .map(function(c) {
-                var containerName = (c.typeof().follow().toComplexType()).getComponentContainer().followName();
-                return macro @:privateAccess $i{ containerName }.inst().add(__entity__, $c);
-            });
-
-        var body = []
-            .concat(
-                addComponentsToContainersExprs
-            )
-            .concat([ 
-                macro if (__entity__.isActive()) {
-                    for (v in echoes.Workflow.views) {
-                        @:privateAccess v.addIfMatched(__entity__);
-                    }
-                }
-            ])
-            .concat([ 
-                macro return __entity__ 
-            ]);
-
-        var ret = macro #if (haxe_ver >= 4) inline #end ( function(__entity__:echoes.Entity) $b{body} )($self);
-
-        return ret;
+        return EntityTools.add(self, components);
     }
 
     /**
@@ -139,45 +113,7 @@ abstract Entity(Int) from Int to Int {
      * @return `Entity`
      */
     macro public function remove(self:Expr, types:Array<ExprOf<Class<Any>>>):ExprOf<echoes.Entity> {
-        if (types.length == 0) {
-            Context.error('Required one or more Component Types', Context.currentPos());
-        }
-
-        var cts = types
-            .map(function(type) {
-                return type.parseComplexType();
-            });
-
-        var removeComponentsFromContainersExprs = cts
-            .map(function(ct) {
-                return ct.getComponentContainer().followName();
-            })
-            .map(function(componentContainerClassName) {
-                return macro @:privateAccess $i{ componentContainerClassName }.inst().remove(__entity__);
-            });
-
-        var removeEntityFromRelatedViewsExprs = cts
-            .map(function(ct) {
-                return ct.getViewsOfComponent().followName();
-            })
-            .map(function(viewsOfComponentClassName) {
-                return macro @:privateAccess $i{ viewsOfComponentClassName }.inst().removeIfMatched(__entity__);
-            });
-
-        var body = []
-            .concat([ 
-                macro if (__entity__.isActive()) $b{ removeEntityFromRelatedViewsExprs }
-            ])
-            .concat(
-                removeComponentsFromContainersExprs
-            )
-            .concat([ 
-                macro return __entity__ 
-            ]);
-
-        var ret = macro #if (haxe_ver >= 4) inline #end ( function(__entity__:echoes.Entity) $b{body} )($self);
-
-        return ret;
+        return EntityTools.remove(self, [for(type in types) type.parseComplexType()]);
     }
 
     /**
@@ -187,11 +123,7 @@ abstract Entity(Int) from Int to Int {
      * @return `T:Any` component instance
      */
     macro public function get<T>(self:Expr, type:ExprOf<Class<T>>):ExprOf<T> {
-        var containerName = type.parseComplexType().getComponentContainer().followName();
-
-        var ret = macro $i{ containerName }.inst().get($self);
-
-        return ret;
+        return EntityTools.get(self, type.parseComplexType());
     }
 
     /**
@@ -200,11 +132,7 @@ abstract Entity(Int) from Int to Int {
      * @return `Bool`
      */
     macro public function exists(self:Expr, type:ExprOf<Class<Any>>):ExprOf<Bool> {
-        var containerName = type.parseComplexType().getComponentContainer().followName();
-
-        var ret = macro $i{ containerName }.inst().exists($self);
-
-        return ret;
+        return EntityTools.exists(self, type.parseComplexType());
     }
 
 

--- a/src/echoes/Entity.hx
+++ b/src/echoes/Entity.hx
@@ -105,7 +105,7 @@ abstract Entity(Int) from Int to Int {
      * @return `Entity`
      */
     macro public function remove(self:Expr, types:Array<ExprOf<Class<Any>>>):ExprOf<echoes.Entity> {
-        return EntityTools.remove(self, [for(type in types) type.parseClassType()]);
+        return EntityTools.remove(self, [for(type in types) type.parseComplexType()]);
     }
 
     /**
@@ -115,7 +115,7 @@ abstract Entity(Int) from Int to Int {
      * @return `T:Any` component instance
      */
     macro public function get<T>(self:Expr, type:ExprOf<Class<T>>):ExprOf<T> {
-        return EntityTools.get(self, type.parseClassType());
+        return EntityTools.get(self, type.parseComplexType());
     }
 
     /**
@@ -124,7 +124,7 @@ abstract Entity(Int) from Int to Int {
      * @return `Bool`
      */
     macro public function exists(self:Expr, type:ExprOf<Class<Any>>):ExprOf<Bool> {
-        return EntityTools.exists(self, type.parseClassType());
+        return EntityTools.exists(self, type.parseComplexType());
     }
 
 

--- a/src/echoes/SystemList.hx
+++ b/src/echoes/SystemList.hx
@@ -24,7 +24,7 @@ class SystemList implements ISystem {
 
     var activated = false;
 
-	var timestep:Timestep;
+    var timestep:Timestep;
 
 	public function new(?timestep:Timestep) {
         this.timestep = timestep != null ? timestep : new Timestep();

--- a/src/echoes/SystemList.hx
+++ b/src/echoes/SystemList.hx
@@ -2,6 +2,7 @@ package echoes;
 
 import echoes.core.ISystem;
 import echoes.utils.LinkedList;
+import echoes.utils.Timestep;
 
 /**
  * SystemList  
@@ -23,8 +24,11 @@ class SystemList implements ISystem {
 
     var activated = false;
 
+	var timestep:Timestep;
 
-    public function new() { }
+	public function new(?timestep:Timestep) {
+        this.timestep = timestep != null ? timestep : new Timestep();
+    }
 
 
     @:noCompletion @:final public function __activate__() {
@@ -35,8 +39,11 @@ class SystemList implements ISystem {
     }
 
     @:noCompletion @:final public function __update__(dt:Float) {
-        for (s in systems) {
-            s.__update__(dt);
+		timestep.advance(dt);
+		for(step in timestep) {
+			for (s in systems) {
+                s.__update__(step);
+            }
         }
     }
 

--- a/src/echoes/core/macro/AbstractEntity.hx
+++ b/src/echoes/core/macro/AbstractEntity.hx
@@ -321,7 +321,9 @@ class AbstractEntity {
 			array.push({
 				access: [AInline],
 				kind: FFun({
-					args: [{name: "value", type: fieldData.type}],
+					//On static platforms, setting opt:true is the
+					//easiest way to allow null values.
+					args: [{name: "value", type: fieldData.type, opt: true}],
 					expr: @:pos(fieldData.pos) macro {
 						if(value == null) {
 							this.remove($typeExpr);

--- a/src/echoes/core/macro/AbstractEntity.hx
+++ b/src/echoes/core/macro/AbstractEntity.hx
@@ -36,13 +36,13 @@ import echoes.Entity;
  */
 class AbstractEntity {
 	#if !macro
-	
+
 	public static function build():Array<Field> {
 		return [];
 	}
-	
+
 	#else
-	
+
 	private static var defaultFields:Array<Field> = [
 		{
 			access:[AInline],
@@ -67,13 +67,13 @@ class AbstractEntity {
 			pos: (macro null).pos
 		}
 	];
-	
+
 	private static var fieldName:String = null;
 	private static var getField:Expr = null;
-	
+
 	public static function build():Array<Field> {
 		var fields:Array<Field> = Context.getBuildFields();
-		
+
 		switch(Context.getLocalType()) {
 			case TInst(_.get().kind => KAbstractImpl(_.get().type => parent), _):
 				var lastName:String = null;
@@ -99,22 +99,22 @@ class AbstractEntity {
 			default:
 				return fields;
 		}
-		
+
 		var blueprint:BlueprintData = BlueprintData.current();
-		
+
 		if(!blueprint.type.meta.has(":forward")) {
 			blueprint.type.meta.add(":forward", [], blueprint.type.pos);
 		}
-		
+
 		var reservedFields:Array<String> = [];
 		var newFields:Array<Field> = defaultFields.copy();
 		var fieldNames:Array<String> = [];
-		
+
 		var i:Int = fields.length;
 		while(--i >= 0) {
 			var field:Field = fields[i];
 			var remove:Bool = false;
-			
+
 			if(reservedFields.indexOf(field.name) >= 0) {
 				Context.warning('${field.name} is reserved and will be overwritten', field.pos);
 				fields.splice(i, 1);
@@ -125,10 +125,10 @@ class AbstractEntity {
 						if(field.access.indexOf(AStatic) >= 0) {
 							continue;
 						}
-						
+
 						//Turn instance variables into properties.
 						field.kind = FProp("get", "set", t, null);
-						
+
 						for(variable in blueprint.variables) {
 							if(variable.name == field.name) {
 								makeAccessors(variable, newFields);
@@ -139,7 +139,7 @@ class AbstractEntity {
 						if(field.access.indexOf(AStatic) < 0) {
 							throw "Assertion failed: the Haxe compiler no longer makes properties static";
 						}
-						
+
 						//Properties can mostly be left as-is, as long as they don't have an underlying variable.
 						if(get == "null" || get == "never") {
 							get = "never";
@@ -151,9 +151,9 @@ class AbstractEntity {
 						} else {
 							set = "set";
 						}
-						
+
 						field.kind = FProp(get, set, t, null);
-						
+
 						for(variable in blueprint.variables) {
 							if(variable.name == field.name) {
 								makeAccessors(variable, get == "get", set == "set", newFields);
@@ -166,7 +166,7 @@ class AbstractEntity {
 							remove = true;
 							break;
 						}
-						
+
 						//Most functions can be left as-is. They will automatically use any necessary getters and setters.
 						//However, the getters and setters themselves need to access their values differently.
 						else if(StringTools.startsWith(field.name, "get_") || StringTools.startsWith(field.name, "set_")) {
@@ -175,20 +175,20 @@ class AbstractEntity {
 								try {
 									returnType = TypeTools.toComplexType(Context.typeof(func.expr).followMono());
 								} catch(e:Dynamic) {}
-								
+
 								if(returnType == null) {
 									Context.error("Explicit return type required for this function", field.pos);
 									remove = true;
 									break;
 								}
 							}
-							
+
 							fieldName = field.name.substr(4);
 							getField = (macro this).get(returnType);
 							func.expr = func.expr.map(replaceVariableAccess);
 						}
 				}
-				
+
 				//Remove @:isVar from anything and everything.
 				if(field.meta != null) {
 					var m:Int = field.meta.length;
@@ -200,14 +200,14 @@ class AbstractEntity {
 					}
 				}
 			}
-			
+
 			if(remove) {
 				fields.splice(i, 1);
 			} else {
 				fieldNames.push(field.name);
 			}
 		}
-		
+
 		//Add conversion functions.
 		var lastType:Type = blueprint.type.type;
 		var parentBlueprint:BlueprintData = blueprint.parentData;
@@ -223,15 +223,15 @@ class AbstractEntity {
 				meta: [{name: ":to", pos: parentBlueprint.type.pos}],
 				pos: parentBlueprint.type.pos
 			});
-			
+
 			//Instead of trying to make a complex type based on the abstract
 			//declaration, record the type used by the child abstract. This
 			//ensures type parameters are included.
 			lastType = parentBlueprint.type.type;
-			
+
 			parentBlueprint = parentBlueprint.parentData;
 		}
-		
+
 		//Make sure not to add any redundant fields.
 		for(newField in newFields) {
 			if(fieldNames.indexOf(newField.name) >= 0) {
@@ -244,7 +244,7 @@ class AbstractEntity {
 							break;
 						}
 					}
-					
+
 					if(fieldNames.indexOf(newField.name) >= 0) {
 						continue;
 					}
@@ -253,23 +253,23 @@ class AbstractEntity {
 					continue;
 				}
 			}
-			
+
 			fields.push(newField);
 			fieldNames.push(newField.name);
 		}
-		
+
 		//TODO: convert to Entity, Int, and any underlying types, but only
 		//if "to Entity" etc. isn't already there.
-		
+
 		return fields;
 	}
-	
+
 	private static function dotAccessExpr(pack:Array<String>, name:String):Expr {
 		var packWithName:Array<String> = pack.copy();
 		packWithName.push(name);
 		return macro $p{packWithName};
 	}
-	
+
 	private static function complexTypeExpr(complexType:ComplexType, pos:Position):Expr {
 		switch(complexType) {
 			case TPath({pack: pack, name: name, params: params}):
@@ -286,7 +286,7 @@ class AbstractEntity {
 				return null;
 		}
 	}
-	
+
 	private static function replaceVariableAccess(expr:Expr):Expr {
 		switch(expr.expr) {
 			case EReturn({expr: EBinop(OpAssign, {expr: EConst(CIdent(c))}, e)}) if(c == fieldName):
@@ -300,7 +300,7 @@ class AbstractEntity {
 				return expr.map(replaceVariableAccess);
 		}
 	}
-	
+
 	private static function makeAccessors(fieldData:BlueprintVariable, ?getter:Bool = true, ?setter:Bool = true, array:Array<Field>):Void {
 		if(getter) {
 			var get:Expr = (macro this).get(fieldData.type);
@@ -315,7 +315,7 @@ class AbstractEntity {
 				pos: fieldData.pos
 			});
 		}
-		
+
 		if(setter) {
 			var typeExpr:Expr = complexTypeExpr(fieldData.type, fieldData.pos);
 			array.push({
@@ -339,57 +339,57 @@ class AbstractEntity {
 			});
 		}
 	}
-	
+
 	#end
 }
 
 class BlueprintData {
 	#if macro
-	
+
 	public static var allData:Array<BlueprintData> = [];
-	
+
 	private static function typePathToString(path:TypePath):String {
 		var result:String;
-		
+
 		if(path.pack.length > 0) {
 			result = path.pack.join(".") + "." + path.name;
 		} else {
 			result = path.name;
 		}
-		
+
 		if(path.sub != null) {
 			result += "." + path.sub;
 		}
-		
+
 		return result;
 	}
-	
+
 	private static function baseTypeToString(type:BaseType):String {
 		var result:String;
-		
+
 		result = type.module;
-		
+
 		if(!StringTools.endsWith(type.module, "." + type.name)) {
 			result += "." + type.name;
 		}
-		
+
 		return result;
 	}
-	
+
 	public static inline function byType(type:BaseType):BlueprintData {
 		return byQualifiedName(baseTypeToString(type));
 	}
-	
+
 	public static function byQualifiedName(qualifiedName:String):BlueprintData {
 		for(data in allData) {
 			if(data.qualifiedName == qualifiedName) {
 				return data;
 			}
 		}
-		
+
 		return new BlueprintData(Context.getType(qualifiedName));
 	}
-	
+
 	public static function current():Null<BlueprintData> {
 		var type:Type = Context.getLocalType();
 		switch(type) {
@@ -402,34 +402,34 @@ class BlueprintData {
 						break;
 					}
 				}
-				
+
 				if(data == null) {
 					data = new BlueprintData(type);
 				}
-				
+
 				if(data.variables.length == 0) {
 					data.init(Context.getBuildFields());
 				}
-				
+
 				return data;
 			default:
 				return null;
 		}
 	}
-	
+
 	public var type:AbstractType;
 	public var qualifiedName:String;
-	
+
 	/**
 	 * May not be defined unless you accessed this via current().
 	 */
 	public var variables:Array<BlueprintVariable> = [];
-	
+
 	/**
 	 * Null indicates that this inherits directly from Entity.
 	 */
 	public var parentData:Null<BlueprintData>;
-	
+
 	private function new(fromType:Type) {
 		switch(fromType) {
 			case TInst(_.get().kind => KAbstractImpl(_.get() => abstractType), _)
@@ -438,11 +438,11 @@ class BlueprintData {
 			default:
 				throw fromType + " is not abstract";
 		}
-		
+
 		qualifiedName = baseTypeToString(type);
-		
+
 		allData.push(this);
-		
+
 		switch(TypeTools.toComplexType(type.type.followMono())) {
 			case TPath({pack: ["echoes"], name: "Entity"}):
 				parentData = null;
@@ -456,10 +456,10 @@ class BlueprintData {
 				Context.error("Unable to parse underlying type: " + unrecognized, type.pos);
 		}
 	}
-	
+
 	private function init(fields:Array<Field>):Void {
 		var printer:Printer = new Printer();
-		
+
 		for(field in fields) {
 			//Skip static variables, but not properties.
 			switch(field.kind) {
@@ -469,14 +469,14 @@ class BlueprintData {
 					}
 				default:
 			}
-			
+
 			switch(field.kind) {
 				case FVar(type, expr), FProp(_, _, type, expr):
 					var coerce:Bool;
-					
+
 					if(type == null) {
 						type = TypeTools.toComplexType(Context.typeof(expr).followMono());
-						
+
 						switch(expr.expr) {
 							case ENew(_, _):
 								coerce = true;
@@ -490,23 +490,23 @@ class BlueprintData {
 						type = TypeTools.toComplexType(ComplexTypeTools.toType(type).followMono());
 						coerce = true;
 					}
-					
+
 					var printedType:String = printer.printComplexType(type);
-					
+
 					if(printedType == "Int" || printedType == "StdTypes.Int") {
 						Context.error("Int is reserved for entity ids - consider using a typedef or abstract", field.pos);
 					} else if(printedType == "Float" || printedType == "StdTypes.Float") {
 						Context.error("Float is reserved for lengths of time - consider using a typedef or abstract", field.pos);
 					}
-					
+
 					for(variable in variables) {
 						if(printedType == variable.printedType) {
 							Context.error("Too many " + printedType + " components", field.pos);
 						}
 					}
-					
+
 					var overwrite:Bool = field.access.indexOf(AOverride) >= 0;
-					
+
 					variables.push({
 						type:type,
 						printedType:printedType,
@@ -520,7 +520,7 @@ class BlueprintData {
 			}
 		}
 	}
-	
+
 	#end
 }
 

--- a/src/echoes/core/macro/AbstractEntity.hx
+++ b/src/echoes/core/macro/AbstractEntity.hx
@@ -126,8 +126,7 @@ class AbstractEntity {
 							continue;
 						}
 						
-						//Turn each variable into a static property.
-						field.access.push(AStatic);
+						//Turn instance variables into properties.
 						field.kind = FProp("get", "set", t, null);
 						
 						for(variable in blueprint.variables) {

--- a/src/echoes/core/macro/AbstractEntity.hx
+++ b/src/echoes/core/macro/AbstractEntity.hx
@@ -1,0 +1,544 @@
+package echoes.core.macro;
+
+import haxe.macro.ComplexTypeTools;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Printer;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+
+#if macro
+using echoes.core.macro.ComponentBuilder;
+using echoes.core.macro.EntityTools;
+using echoes.core.macro.MacroTools;
+using haxe.EnumTools;
+using haxe.macro.ExprTools;
+#else
+import echoes.Entity;
+#end
+
+/**
+ * Any abstract extending Entity can be used to access components
+ * as if they were instance variables. For example, this:
+ * 
+ * typedef Color = Int;
+ * abstract ColorfulEntity(Entity) {
+ *     public var color:Color;
+ * }
+ * 
+ * Enables this:
+ * 
+ * var redBall = new ColorfulEntity();
+ * redBall.color = 0xFF0000;
+ * redBall.add(new SphericalHitbox(5));
+ * redBall.add(new ElasticCollision(1));
+ * trace(StringTools.hex(redBall.get(Color))); //FF0000
+ */
+class AbstractEntity {
+	#if !macro
+	
+	public static function build():Array<Field> {
+		return [];
+	}
+	
+	#else
+	
+	private static var defaultFields:Array<Field> = [
+		{
+			access:[AInline],
+			kind: FFun({
+				args: [],
+				expr: macro return cast this,
+				ret: macro:Int
+			}),
+			name: "toInt",
+			meta: [{name: ":to", pos: (macro null).pos}],
+			pos: (macro null).pos
+		},
+		{
+			access:[AInline],
+			kind: FFun({
+				args: [],
+				expr: macro return cast this,
+				ret: macro:echoes.Entity
+			}),
+			name: "toEntity",
+			meta: [{name: ":to", pos: (macro null).pos}],
+			pos: (macro null).pos
+		}
+	];
+	
+	private static var fieldName:String = null;
+	private static var getField:Expr = null;
+	
+	public static function build():Array<Field> {
+		var fields:Array<Field> = Context.getBuildFields();
+		
+		switch(Context.getLocalType()) {
+			case TInst(_.get().kind => KAbstractImpl(_.get().type => parent), _):
+				var lastName:String = null;
+				while(parent != null) {
+					switch(parent) {
+						case TAbstract(_.get() => parentAbstract, _):
+							if(parentAbstract.module == "StdTypes") {
+								return fields;
+							} else if(parentAbstract.name == lastName) {
+								return fields;
+							} else if(parentAbstract.name == "Entity"
+								&& parentAbstract.pack.length == 1 && parentAbstract.pack[0] == "echoes") {
+								parent = null;
+								break;
+							} else {
+								lastName = parentAbstract.name;
+								parent = parentAbstract.type;
+							}
+						default:
+							return fields;
+					}
+				}
+			default:
+				return fields;
+		}
+		
+		var blueprint:BlueprintData = BlueprintData.current();
+		
+		if(!blueprint.type.meta.has(":forward")) {
+			blueprint.type.meta.add(":forward", [], blueprint.type.pos);
+		}
+		
+		var reservedFields:Array<String> = [];
+		var newFields:Array<Field> = defaultFields.copy();
+		var fieldNames:Array<String> = [];
+		
+		var i:Int = fields.length;
+		while(--i >= 0) {
+			var field:Field = fields[i];
+			var remove:Bool = false;
+			
+			if(reservedFields.indexOf(field.name) >= 0) {
+				Context.warning('${field.name} is reserved and will be overwritten', field.pos);
+				fields.splice(i, 1);
+			} else {
+				switch(field.kind) {
+					case FVar(t, e):
+						//Static variables should be left alone.
+						if(field.access.indexOf(AStatic) >= 0) {
+							continue;
+						}
+						
+						//Turn each variable into a static property.
+						field.access.push(AStatic);
+						field.kind = FProp("get", "set", t, e);
+						
+						makeAccessors(field, newFields);
+					case FProp(get, set, t, e):
+						if(field.access.indexOf(AStatic) < 0) {
+							throw "Assertion failed: the Haxe compiler no longer makes properties static";
+						}
+						
+						//Properties can mostly be left as-is, as long as they don't have an underlying variable.
+						if(get == "null" || get == "never") {
+							get = "never";
+						} else {
+							get = "get";
+						}
+						if(set == "null" || set == "never") {
+							set = "never";
+						} else {
+							set = "set";
+						}
+						
+						field.kind = FProp(get, set, t, e);
+						
+						makeAccessors(field, get == "get", set == "set", newFields);
+					case FFun(func):
+						if(func.expr == null) {
+							Context.warning("Missing function body", field.pos);
+							remove = true;
+							break;
+						}
+						
+						//Most functions can be left as-is. They will automatically use any necessary getters and setters.
+						//However, the getters and setters themselves need to access their values differently.
+						else if(StringTools.startsWith(field.name, "get_") || StringTools.startsWith(field.name, "set_")) {
+							var returnType:ComplexType = func.ret;
+							if(returnType == null) {
+								try {
+									returnType = TypeTools.toComplexType(Context.typeof(func.expr).followMono());
+								} catch(e:Dynamic) {}
+								
+								if(returnType == null) {
+									Context.error("Explicit return type required for this function", field.pos);
+									remove = true;
+									break;
+								}
+							}
+							
+							fieldName = field.name.substr(4);
+							getField = (macro this).get(returnType);
+							func.expr = func.expr.map(replaceVariableAccess);
+						}
+				}
+				
+				//Remove @:isVar from anything and everything.
+				if(field.meta != null) {
+					var m:Int = field.meta.length;
+					while(--m >= 0) {
+						if(field.meta[m].name == ":isVar") {
+							Context.warning("Instance variables are not allowed", field.meta[m].pos);
+							field.meta.splice(i, 1);
+						}
+					}
+				}
+			}
+			
+			if(remove) {
+				fields.splice(i, 1);
+			} else {
+				fieldNames.push(field.name);
+			}
+		}
+		
+		//Add conversion functions.
+		var lastType:Type = blueprint.type.type;
+		var parentBlueprint:BlueprintData = blueprint.parentData;
+		while(parentBlueprint != null) {
+			newFields.push({
+				access:[AInline],
+				kind: FFun({
+					args: [],
+					expr: macro return cast this,
+					ret: TypeTools.toComplexType(lastType)
+				}),
+				name: "to" + parentBlueprint.type.name,
+				meta: [{name: ":to", pos: parentBlueprint.type.pos}],
+				pos: parentBlueprint.type.pos
+			});
+			
+			//Instead of trying to make a complex type based on the abstract
+			//declaration, record the type used by the child abstract. This
+			//ensures type parameters are included. Not that type parameters
+			//are recommended.
+			lastType = parentBlueprint.type.type;
+			
+			parentBlueprint = parentBlueprint.parentData;
+		}
+		
+		//Make sure not to add any redundant fields.
+		for(newField in newFields) {
+			if(fieldNames.indexOf(newField.name) >= 0) {
+				//Private fields can simply be renamed.
+				if(newField.access.indexOf(APublic) < 0) {
+					var i:Int = 0;
+					while(++i < 100) {
+						if(fieldNames.indexOf(newField.name + i) < 0) {
+							newField.name += i;
+							break;
+						}
+					}
+					
+					if(fieldNames.indexOf(newField.name) >= 0) {
+						continue;
+					}
+				} else {
+					//Public fields must be skipped.
+					continue;
+				}
+			}
+			
+			fields.push(newField);
+			fieldNames.push(newField.name);
+		}
+		
+		//TODO: convert to Entity, Int, and any underlying types, but only
+		//if "to Entity" etc. isn't already there.
+		
+		return fields;
+	}
+	
+	private static function dotAccessExpr(pack:Array<String>, name:String):Expr {
+		var packWithName:Array<String> = pack.copy();
+		packWithName.push(name);
+		return macro $p{packWithName};
+	}
+	
+	private static function complexTypeExpr(complexType:ComplexType):Expr {
+		switch(complexType) {
+			case TPath({pack: pack, name: name}):
+				if(pack != null && pack.length > 0) {
+					return dotAccessExpr(pack, name);
+				} else {
+					return macro $i{name};
+				}
+			default:
+				return null;
+		}
+	}
+	
+	private static function replaceVariableAccess(expr:Expr):Expr {
+		switch(expr.expr) {
+			case EReturn({expr: EBinop(OpAssign, {expr: EConst(CIdent(c))}, e)}) if(c == fieldName):
+				//Avoid duplicating $e; it could include a costly function call.
+				return @:pos(expr.pos) macro return { this.add($e); $getField; };
+			case EBinop(OpAssign, {expr: EConst(CIdent(c))}, e) if(c == fieldName):
+				return @:pos(expr.pos) macro this.add($e);
+			case EConst(CIdent(c)) if(c == fieldName):
+				return getField;
+			default:
+				return expr.map(replaceVariableAccess);
+		}
+	}
+	
+	private static function makeAccessors(field:Field, ?getter:Bool = true, ?setter:Bool = true, array:Array<Field>):Void {
+		var complexType:ComplexType;
+		switch(field.kind) {
+			case FVar(t, e) | FProp(_, _, t, e):
+				if(t != null) {
+					//Get a fully-qualified type.
+					complexType = TypeTools.toComplexType(ComplexTypeTools.toType(t));
+				} else {
+					if(e == null) {
+						Context.error("Missing type", field.pos);
+						return;
+					}
+					
+					try {
+						t = TypeTools.toComplexType(Context.typeof(e).followMono());
+					} catch(e:Dynamic) {}
+					
+					if(t != null) {
+						complexType = t;
+					} else {
+						Context.error("Explicit type required for this property", field.pos);
+						return;
+					}
+				}
+			default:
+				return;
+		}
+		
+		if(getter) {
+			var get:Expr = (macro this).get(complexType);
+			array.push({
+				access: [AInline],
+				kind: FFun({
+					args: [],
+					expr: @:pos(field.pos) macro return $get,
+					ret: complexType
+				}),
+				name: "get_" + field.name,
+				pos: field.pos
+			});
+		}
+		
+		if(setter) {
+			//var add:Expr = (macro this).add([macro value], [complexType]);
+			array.push({
+				access: [AInline],
+				kind: FFun({
+					args: [{name: "value", type: complexType}],
+					expr: @:pos(field.pos) macro {
+						this.add(value);
+						return value;
+					},
+					ret: complexType
+				}),
+				name: "set_" + field.name,
+				pos: field.pos
+			});
+		}
+	}
+	
+	#end
+}
+
+class BlueprintData {
+	#if macro
+	
+	public static var allData:Array<BlueprintData> = [];
+	
+	private static function typePathToString(path:TypePath):String {
+		var result:String;
+		
+		if(path.pack.length > 0) {
+			result = path.pack.join(".") + "." + path.name;
+		} else {
+			result = path.name;
+		}
+		
+		if(path.sub != null) {
+			result += "." + path.sub;
+		}
+		
+		return result;
+	}
+	
+	private static function baseTypeToString(type:BaseType):String {
+		var result:String;
+		
+		if(type.pack.length > 0) {
+			result = type.pack.join(".") + "." + type.module;
+		} else {
+			result = type.module;
+		}
+		
+		if(type.module != type.name) {
+			result += "." + type.name;
+		}
+		
+		return result;
+	}
+	
+	public static inline function byType(type:BaseType):BlueprintData {
+		return byQualifiedName(baseTypeToString(type));
+	}
+	
+	public static function byQualifiedName(qualifiedName:String):BlueprintData {
+		for(data in allData) {
+			if(data.qualifiedName == qualifiedName) {
+				return data;
+			}
+		}
+		
+		return new BlueprintData(Context.getType(qualifiedName));
+	}
+	
+	public static function current():Null<BlueprintData> {
+		var type:Type = Context.getLocalType();
+		switch(type) {
+			case TInst(_.get().kind => KAbstractImpl(_.get() => abstractType), _):
+				var qualifiedName:String = baseTypeToString(abstractType);
+				var data:BlueprintData = null;
+				for(d in allData) {
+					if(d.qualifiedName == qualifiedName) {
+						data = d;
+						break;
+					}
+				}
+				
+				if(data == null) {
+					data = new BlueprintData(type);
+				}
+				
+				if(data.variables.length == 0) {
+					data.init(Context.getBuildFields());
+				}
+				
+				return data;
+			default:
+				return null;
+		}
+	}
+	
+	public var type:AbstractType;
+	public var qualifiedName:String;
+	
+	/**
+	 * May not be defined unless you accessed this via current().
+	 */
+	public var variables:Array<BlueprintVariable> = [];
+	
+	/**
+	 * Null indicates that this inherits directly from Entity.
+	 */
+	public var parentData:Null<BlueprintData>;
+	
+	private function new(fromType:Type) {
+		switch(fromType) {
+			case TInst(_.get().kind => KAbstractImpl(_.get() => abstractType), _)
+				| TAbstract(_.get() => abstractType, _):
+				type = abstractType;
+			default:
+				throw fromType + " is not abstract";
+		}
+		
+		qualifiedName = baseTypeToString(type);
+		
+		allData.push(this);
+		
+		switch(TypeTools.toComplexType(type.type.followMono())) {
+			case TPath({pack: ["echoes"], name: "Entity"}):
+				parentData = null;
+			case TPath(path):
+				parentData = byQualifiedName(typePathToString(path));
+				if(parentData == this) {
+					Context.error(type.name + " should not be its own parent", type.pos);
+					parentData = null;
+				}
+			case unrecognized:
+				Context.error("Unable to parse underlying type: " + unrecognized, type.pos);
+		}
+	}
+	
+	private function init(fields:Array<Field>):Void {
+		var printer:Printer = new Printer();
+		
+		for(field in fields) {
+			if(field.access == null || field.access.indexOf(AStatic) < 0) {
+				switch(field.kind) {
+					case FVar(type, expr), FProp(_, _, type, expr):
+						var coerce:Bool;
+						
+						if(type == null) {
+							type = TypeTools.toComplexType(Context.typeof(expr));
+							
+							switch(expr.expr) {
+								case ENew(_, _):
+									coerce = true;
+								case null:
+									Context.error("Please specify a type", field.pos);
+								default:
+									coerce = false;
+							}
+						} else {
+							//Convert back and forth to get a fully-qualified type.
+							type = TypeTools.toComplexType(ComplexTypeTools.toType(type));
+							coerce = true;
+						}
+						
+						var printedType:String = printer.printComplexType(type);
+						
+						if(printedType == "Int" || printedType == "StdTypes.Int") {
+							Context.error("Int is reserved for entity ids - consider using a typedef or abstract", field.pos);
+						} else if(printedType == "Float" || printedType == "StdTypes.Float") {
+							Context.error("Float is reserved for lengths of time - consider using a typedef or abstract", field.pos);
+						}
+						
+						if(expr != null) {
+							for(variable in variables) {
+								if(printedType == variable.printedType) {
+									Context.error("Too many " + printedType + " components", field.pos);
+								}
+							}
+							
+							var overwrite:Bool = field.access.indexOf(AOverride) >= 0;
+							
+							variables.push({
+								type:type,
+								printedType:printedType,
+								name:field.name,
+								expr:expr,
+								overwrite:overwrite,
+								coerce:coerce,
+								pos:field.pos
+							});
+						}
+					default:
+				}
+			}
+		}
+	}
+	
+	#end
+}
+
+typedef BlueprintVariable = {
+	type:ComplexType,
+	printedType:String,
+	name:String,
+	expr:Expr,
+	overwrite:Bool,
+	coerce:Bool,
+	pos:Position
+	//, requestedData:Array<RequestedData>
+};

--- a/src/echoes/core/macro/AbstractEntity.hx
+++ b/src/echoes/core/macro/AbstractEntity.hx
@@ -226,8 +226,7 @@ class AbstractEntity {
 			
 			//Instead of trying to make a complex type based on the abstract
 			//declaration, record the type used by the child abstract. This
-			//ensures type parameters are included. Not that type parameters
-			//are recommended.
+			//ensures type parameters are included.
 			lastType = parentBlueprint.type.type;
 			
 			parentBlueprint = parentBlueprint.parentData;
@@ -275,12 +274,13 @@ class AbstractEntity {
 		switch(complexType) {
 			case TPath({pack: pack, name: name, params: params}):
 				if(params != null && params.length > 0) {
-					Context.error("Parameters currently aren't supported. Use a typedef to get around this.", pos);
-				}
-				if(pack != null && pack.length > 0) {
-					return dotAccessExpr(pack, name);
+					return macro (_:$complexType);
 				} else {
-					return macro $i{name};
+					if(pack != null && pack.length > 0) {
+						return dotAccessExpr(pack, name);
+					} else {
+						return macro $i{name};
+					}
 				}
 			default:
 				return null;

--- a/src/echoes/core/macro/EntityTools.hx
+++ b/src/echoes/core/macro/EntityTools.hx
@@ -1,0 +1,114 @@
+package echoes.core.macro;
+
+#if macro
+import haxe.macro.Expr;
+using echoes.core.macro.ComponentBuilder;
+using echoes.core.macro.ViewsOfComponentBuilder;
+using echoes.core.macro.MacroTools;
+using haxe.macro.Context;
+using Lambda;
+
+/**
+ * Because Haxe 4 no longer allows calling macros from macros, entity manipulation
+ * functions are also available in static form.
+ */
+class EntityTools {
+
+
+    /**
+     * Adds a specified components to this entity.  
+     * If a component with the same type is already added - it will be replaced 
+     * @param components comma separated list of components of `Any` type
+     * @return `Entity`
+     */
+	public static function add(self:Expr, components:Array<ExprOf<Any>>):ExprOf<echoes.Entity> {
+        if (components.length == 0) {
+            Context.error("Nothing to add; required one or more components", Context.currentPos());
+        }
+
+        var addComponentsToContainersExprs = components
+            .map(function(c) {
+                var containerName = (c.typeof().follow().toComplexType()).getComponentContainer().followName();
+                return macro @:privateAccess $i{ containerName }.inst().add(__entity__, $c);
+            });
+
+        return macro #if (haxe_ver >= 4) inline #end
+            ( function (__entity__:echoes.Entity) {
+                $b{addComponentsToContainersExprs}
+
+                if (__entity__.isActive()) {
+                    for (v in echoes.Workflow.views) {
+                        @:privateAccess v.addIfMatched(__entity__);
+                    }
+                }
+
+                return __entity__;
+            } )($self);
+    }
+
+    /**
+     * Removes a component from this entity with specified type  
+     * @param types `ComplexType` types of components that should be removed
+     * @return `Entity`
+     */
+    public static function remove(self:Expr, types:Array<ComplexType>):ExprOf<echoes.Entity> {
+        if (types.length == 0) {
+            Context.error("Nothing to remove; required one or more component types", Context.currentPos());
+        }
+
+        var removeComponentsFromContainersExprs = cts
+            .map(function(ct) {
+                return ct.getComponentContainer().followName();
+            })
+            .map(function(componentContainerClassName) {
+                return macro @:privateAccess $i{ componentContainerClassName }.inst().remove(__entity__);
+            });
+
+        var removeEntityFromRelatedViewsExprs = cts
+            .map(function(ct) {
+                return ct.getViewsOfComponent().followName();
+            })
+            .map(function(viewsOfComponentClassName) {
+                return macro @:privateAccess $i{ viewsOfComponentClassName }.inst().removeIfMatched(__entity__);
+            });
+
+        return macro #if (haxe_ver >= 4) inline #end 
+            ( function (__entity__:echoes.Entity) {
+                if (__entity__.isActive()) $b{ removeEntityFromRelatedViewsExprs }
+
+                $b{ removeComponentsFromContainersExprs }
+
+                return __entity__;
+            } )($self);
+    }
+
+    /**
+     * Returns a component of this entity of specified type.  
+     * If a component with specified type is not added to this entity, `null` will be returned 
+     * @param type `Class<T:Any>` type of component
+     * @return `T:Any` component instance
+     */
+    public static function get<T>(self:Expr, complexType:ComplexType):ExprOf<T> {
+        var containerName = complexType.getComponentContainer().followName();
+
+        var ret = macro $i{ containerName }.inst().get($self);
+
+        return ret;
+    }
+
+    /**
+     * Returns `true` if this entity contains a component of specified type, otherwise returns `false` 
+     * @param type `Class<T:Any>` type of component
+     * @return `Bool`
+     */
+    public static function exists(self:Expr, complexType:ComplexType):ExprOf<Bool> {
+        var containerName = complexType.getComponentContainer().followName();
+
+        var ret = macro $i{ containerName }.inst().exists($self);
+
+        return ret;
+	}
+
+
+}
+#end

--- a/src/echoes/core/macro/EntityTools.hx
+++ b/src/echoes/core/macro/EntityTools.hx
@@ -63,7 +63,7 @@ class EntityTools {
             macro @:privateAccess $i{ type.getComponentContainer().followName() }.inst().remove(__entity__)];
 
         var removeEntityFromRelatedViewsExprs = [for(type in types)
-            macro @:privateAccess $i{ type.getComponentContainer().followName() }.inst().removeIfMatched(__entity__)];
+            macro @:privateAccess $i{ type.getViewsOfComponent().followName() }.inst().removeIfMatched(__entity__)];
 
         var ret = macro {
             var __entity__:echoes.Entity = $self;

--- a/src/echoes/core/macro/EntityTools.hx
+++ b/src/echoes/core/macro/EntityTools.hx
@@ -1,0 +1,120 @@
+package echoes.core.macro;
+
+#if macro
+import haxe.macro.Expr;
+using echoes.core.macro.ComponentBuilder;
+using echoes.core.macro.ViewsOfComponentBuilder;
+using echoes.core.macro.MacroTools;
+using haxe.macro.Context;
+using Lambda;
+
+/**
+ * Because Haxe 4 no longer allows calling macros from macros, entity manipulation
+ * functions are also available in static form.
+ */
+class EntityTools {
+
+
+    /**
+     * @param componentTypes (optional) an array with length equal to the number of
+     * components. These will be used instead of calling typeof() on each component.
+     */
+	public static function add(self:Expr, components:Array<ExprOf<Any>>, ?componentTypes:Array<ComplexType>):ExprOf<echoes.Entity> {
+        if (components.length == 0) {
+            Context.error("Nothing to add", Context.currentPos());
+        }
+
+        if (componentTypes == null || components.length != componentTypes.length) {
+            componentTypes = [for(c in components) MacroTools.typeof(c).followMono().toComplexType()];
+        }
+
+        var addComponentsToContainersExprs = [for(i in 0...components.length) {
+            var containerName = componentTypes[i].getComponentContainer().followName();
+            macro @:privateAccess $i{ containerName }.inst().add(__entity__, ${ components[i] });
+        }];
+
+        var ret = macro {
+            var __entity__:echoes.Entity = $self;
+            
+            $b{addComponentsToContainersExprs}
+            
+            if (__entity__.isActive()) {
+                for (v in echoes.Workflow.views) {
+                    @:privateAccess v.addIfMatched(__entity__);
+                }
+            }
+            
+            __entity__;
+        };
+
+        #if echoes_verbose
+        trace(Context.currentPos() + "\n" + new haxe.macro.Printer().printExpr(ret));
+        #end
+
+        return ret;
+    }
+
+    public static function remove(self:Expr, types:Array<ComplexType>):ExprOf<echoes.Entity> {
+        if (types.length == 0) {
+            Context.error("Nothing to remove", Context.currentPos());
+        }
+
+        var removeComponentsFromContainersExprs = [for(type in types)
+            macro @:privateAccess $i{ type.getComponentContainer().followName() }.inst().remove(__entity__)];
+
+        var removeEntityFromRelatedViewsExprs = [for(type in types)
+            macro @:privateAccess $i{ type.getComponentContainer().followName() }.inst().removeIfMatched(__entity__)];
+
+        var ret = macro {
+            var __entity__:echoes.Entity = $self;
+            
+            if (__entity__.isActive()) $b{ removeEntityFromRelatedViewsExprs }
+            
+            $b{ removeComponentsFromContainersExprs }
+            
+            __entity__;
+        };
+
+        #if echoes_verbose
+        trace(Context.currentPos() + "\n" + new haxe.macro.Printer().printExpr(ret));
+        #end
+
+        return ret;
+    }
+
+    /**
+     * Returns a component of this entity of specified type.  
+     * If a component with specified type is not added to this entity, `null` will be returned 
+     * @param type `Class<T:Any>` type of component
+     * @return `T:Any` component instance
+     */
+    public static function get<T>(self:Expr, complexType:ComplexType):ExprOf<T> {
+        var containerName = complexType.getComponentContainer().followName();
+        var ret = macro $i{ containerName }.inst().get($self);
+
+        #if echoes_verbose
+        trace(Context.currentPos() + "\n" + new haxe.macro.Printer().printExpr(ret));
+        #end
+
+        return ret;
+    }
+
+    /**
+     * Returns `true` if this entity contains a component of specified type, otherwise returns `false` 
+     * @param type `Class<T:Any>` type of component
+     * @return `Bool`
+     */
+    public static function exists(self:Expr, complexType:ComplexType):ExprOf<Bool> {
+        var containerName = complexType.getComponentContainer().followName();
+        var ret = macro $i{ containerName }.inst().exists($self);
+
+        #if echoes_verbose
+        trace(Context.currentPos() + "\n" + new haxe.macro.Printer().printExpr(ret));
+        #end
+
+        return ret;
+	}
+
+
+}
+#end

--- a/src/echoes/core/macro/EntityTools.hx
+++ b/src/echoes/core/macro/EntityTools.hx
@@ -5,6 +5,7 @@ import haxe.macro.Expr;
 using echoes.core.macro.ComponentBuilder;
 using echoes.core.macro.ViewsOfComponentBuilder;
 using echoes.core.macro.MacroTools;
+using haxe.macro.ComplexTypeTools;
 using haxe.macro.Context;
 using Lambda;
 
@@ -28,7 +29,14 @@ class EntityTools {
 
         var addComponentsToContainersExprs = components
             .map(function(c) {
-                var containerName = (c.typeof().followMono().toComplexType()).getComponentContainer().followName();
+                var t = switch(c.expr) {
+                    case ENew(tp, _):
+                        TPath(tp).toType();
+                    default:
+                        c.typeof();
+                }
+
+                var containerName = t.followMono().toComplexType().getComponentContainer().followName();
                 return macro @:privateAccess $i{ containerName }.inst().add(__entity__, $c);
             });
 

--- a/src/echoes/core/macro/EntityTools.hx
+++ b/src/echoes/core/macro/EntityTools.hx
@@ -26,7 +26,7 @@ class EntityTools {
         if (components.length == 0) {
             Context.error("Nothing to add; required one or more components", Context.currentPos());
         }
-        
+
         var types = components
             .map(function(c) {
                 var t = switch(c.expr) {

--- a/src/echoes/core/macro/MacroTools.hx
+++ b/src/echoes/core/macro/MacroTools.hx
@@ -72,15 +72,6 @@ class MacroTools {
     }
 
 
-	public static function typeof(e:Expr) {
-		return switch(e.expr) {
-			case ENew(t, _):
-				TPath(t).toType();
-			default:
-				Context.typeof(e);
-		}
-	}
-
     public static function followMono(t:Type) {
         return switch(t) {
             case TMono(_.get() => tt):

--- a/src/echoes/core/macro/MacroTools.hx
+++ b/src/echoes/core/macro/MacroTools.hx
@@ -118,7 +118,16 @@ class MacroTools {
     }
 
 
-    public static function parseClassName(e:Expr) {
+    public static function parseClassType(e:Expr) {
+        return switch(e.expr) {
+            case EParenthesis({expr:ECheckType({expr:EConst(CIdent("_"))}, ct)}):
+                followComplexType(ct);
+            default:
+                followMono(parseClassName(e).getType()).toComplexType();
+        }
+    }
+    
+    private static function parseClassName(e:Expr) {
         return switch(e.expr) {
             case EConst(CIdent(name)): name;
             case EField(path, name): parseClassName(path) + '.' + name;

--- a/src/echoes/core/macro/MacroTools.hx
+++ b/src/echoes/core/macro/MacroTools.hx
@@ -118,25 +118,21 @@ class MacroTools {
     }
 
 
-    public static function parseClassType(e:Expr) {
-        return switch(e.expr) {
-            case EParenthesis({expr:ECheckType({expr:EConst(CIdent("_"))}, ct)}):
-                followComplexType(ct);
+    public static function parseComplexType(e:Expr) {
+        switch(e.expr) {
+            case EParenthesis({expr:ECheckType(_, ct)}):
+                return followComplexType(ct);
             default:
-                followMono(parseClassName(e).getType()).toComplexType();
         }
-    }
-    
-    private static function parseClassName(e:Expr) {
-        return switch(e.expr) {
-            case EConst(CIdent(name)): name;
-            case EField(path, name): parseClassName(path) + '.' + name;
-            case x: 
-                #if (haxe_ver < 4) 
-                throw 'Unexpected $x!';
-                #else
-                Context.error('Unexpected $x!', e.pos);
-                #end 
+
+        var type = new Printer().printExpr(e);
+
+        try {
+
+            return followMono(type.getType()).toComplexType();
+
+        } catch (err:String) {
+            throw 'Failed to parse `$type`. Try making a typedef, or use the special type check syntax: `entity.get((_:MyType))` instead of `entity.get(MyType)`.';
         }
     }
 

--- a/src/echoes/core/macro/MacroTools.hx
+++ b/src/echoes/core/macro/MacroTools.hx
@@ -1,7 +1,6 @@
 package echoes.core.macro;
 
 #if macro
-import haxe.macro.ComplexTypeTools;
 import haxe.macro.Expr;
 import haxe.macro.Expr.Access;
 import haxe.macro.Expr.ComplexType;
@@ -10,7 +9,9 @@ import haxe.macro.Expr.FunctionArg;
 import haxe.macro.Expr.TypePath;
 import haxe.macro.Expr.Position;
 import haxe.macro.Printer;
+import haxe.macro.Type;
 
+using haxe.macro.ComplexTypeTools;
 using haxe.macro.Context;
 using Lambda;
 
@@ -88,8 +89,28 @@ class MacroTools {
     }
 
 
+	public static function typeof(e:Expr) {
+		return switch(e.expr) {
+			case ENew(t, _):
+				TPath(t).toType();
+			default:
+				Context.typeof(e);
+		}
+	}
+
+    public static function followMono(t:Type) {
+        return switch(t) {
+            case TMono(_.get() => tt):
+                followMono(tt);
+            case TAbstract(_.get() => {name:"Null"}, [tt]):
+                followMono(tt);
+            default:
+                t;
+        }
+    }
+
     public static function followComplexType(ct:ComplexType) {
-        return ComplexTypeTools.toType(ct).follow().toComplexType();
+        return followMono(ct.toType()).toComplexType();
     }
 
     public static function followName(ct:ComplexType):String {

--- a/src/echoes/core/macro/ViewBuilder.hx
+++ b/src/echoes/core/macro/ViewBuilder.hx
@@ -48,12 +48,12 @@ class ViewBuilder {
 
             case TAnonymous(_.get() => p):
                 p.fields
-                    .map(function(f) return { cls: f.type.follow().toComplexType() });
+                    .map(function(f) return { cls: f.type.followMono().toComplexType() });
 
             case TFun(args, ret):
                 args
-                    .map(function(a) return a.t.follow().toComplexType())
-                    .concat([ ret.follow().toComplexType() ])
+                    .map(function(a) return a.t.followMono().toComplexType())
+                    .concat([ ret.followMono().toComplexType() ])
                     .filter(function(ct) {
                         return switch (ct) {
                             case (macro:StdTypes.Void): false;
@@ -64,7 +64,7 @@ class ViewBuilder {
 
             case TInst(_, types):
                 types
-                    .map(function(t) return t.follow().toComplexType())
+                    .map(function(t) return t.followMono().toComplexType())
                     .map(function(ct) return { cls: ct });
 
             case x: 

--- a/src/echoes/core/macro/ViewBuilder.hx
+++ b/src/echoes/core/macro/ViewBuilder.hx
@@ -1,5 +1,6 @@
 package echoes.core.macro;
 
+import haxe.crypto.Md5;
 #if macro
 import echoes.core.macro.MacroTools.*;
 import echoes.core.macro.ComponentBuilder.*;
@@ -29,7 +30,11 @@ class ViewBuilder {
     }
 
     public static function getViewName(components:Array<{ cls:ComplexType }>) {
-        return 'ViewOf' + components.map(function(c) return c.cls).packName();
+        var name:String = components.map(function(c) return c.cls).packName();
+        if(name.length > 80) {
+            name = Md5.encode(name);
+        }
+        return 'ViewOf' + name;
     }
 
 

--- a/src/echoes/core/macro/ViewsOfComponentBuilder.hx
+++ b/src/echoes/core/macro/ViewsOfComponentBuilder.hx
@@ -46,7 +46,15 @@ class ViewsOfComponentBuilder {
                         views.push(v);
                     }
 
-                    public inline function removeIfMatched(id:Int) {
+                    public inline function addIfMatched(id:Int) {
+                        for (v in views) {
+                            if (v.isActive()) {
+                                 @:privateAccess v.addIfMatched(id);
+                            }
+                        }
+                    }
+
+                    public inline function removeIfExists(id:Int) {
                         for (v in views) {
                             if (v.isActive()) {
                                  @:privateAccess v.removeIfExists(id);

--- a/src/echoes/utils/Timestep.hx
+++ b/src/echoes/utils/Timestep.hx
@@ -16,10 +16,11 @@ package echoes.utils;
  * 
  * Subclasses use the decorator pattern to allow more
  * customization. You can use this to combine subclasses,
- * applying a cap from `CappedTimestep` with the fixed
- * ticks from `FixedTimestep`. To combine subclasses,
- * create an instance of each, passing the last-created
- * instance to the next constructor.
+ * applying a cap from `CappedTimestep`, the fixed ticks
+ * from `FixedTimestep`, and/or the speed adjustment from
+ * `ScaledTimestep`. To combine subclasses, create an
+ * instance of each, passing the last-created instance to
+ * the next constructor.
  */
 class Timestep {
 
@@ -137,6 +138,29 @@ class CappedTimestep extends Timestep {
 		if(this.time.left > tickCap) {
 			this.time.left = tickCap;
 		}
+	}
+
+
+}
+
+/**
+ * A scaled timestamp multiplies all elapsed time.
+ * Depending on the multiplier, this can speed time up,
+ * slow it down, pause it, or reverse it. (Caution:
+ * reversing time may create edge cases.)
+ */
+class ScaledTimestep extends Timestep {
+
+
+	public var scale:Float;
+
+	public function new(scale:Float = 1, ?nextTimestep:Timestep) {
+		super(nextTimestep);
+		this.scale = scale;
+	}
+
+	public override function advance(time:Float):Void {
+		super.advance(time * scale);
 	}
 
 

--- a/src/echoes/utils/Timestep.hx
+++ b/src/echoes/utils/Timestep.hx
@@ -74,7 +74,7 @@ class Timestep {
 
 private class Time {
 	public var left:Float = 0;
-	
+
 	public inline function new() {
 	}
 }

--- a/src/echoes/utils/Timestep.hx
+++ b/src/echoes/utils/Timestep.hx
@@ -1,0 +1,112 @@
+package echoes.utils;
+
+class Timestep {
+
+
+	var time:Float = 0;
+
+	public function new() {
+	}
+
+	public function advance(time:Float):Void {
+		this.time += time;
+	}
+
+	public function hasNext():Bool return time > 0;
+
+	public function next():Float {
+		var time:Float = time;
+		this.time = 0;
+		return time;
+	}
+
+
+}
+
+class FixedTimestep extends Timestep {
+
+
+	var tickLength:Float;
+
+	public function new(tickLength:Float) {
+		super();
+		this.tickLength = tickLength;
+	}
+
+	public override function hasNext():Bool {
+		return time >= tickLength;
+	}
+
+	public override function next():Float {
+		if(tickLength > 0) {
+			time -= tickLength;
+			return tickLength;
+		} else {
+			return super.next();
+		}
+	}
+
+
+}
+
+class CappedTimestep extends Timestep {
+
+
+	var tickCap:Float;
+
+	/**
+	 * This time will not be used until time advances again.
+	 * Usually this means the next frame.
+	 */
+	var extraTime:Float = 0;
+
+	public function new(tickCap:Float) {
+		super();
+		this.tickCap = tickCap;
+	}
+
+	public override function advance(time:Float):Void {
+		this.time += time + extraTime;
+		extraTime = 0;
+	}
+
+	public override function next():Float {
+		if(time > tickCap) {
+			extraTime += time - tickCap;
+			time = 0;
+			return tickCap;
+		} else {
+			return super.next();
+		}
+	}
+
+
+}
+
+class CappedFixedTimestep extends FixedTimestep {
+
+
+	var extraTime:Float = 0;
+	var tickCap:Float;
+
+	public function new(tickLength:Float, tickCap:Float) {
+		super(tickLength);
+		this.tickCap = tickCap;
+	}
+
+	public override function advance(time:Float):Void {
+		this.time += time + extraTime;
+		extraTime = 0;
+	}
+
+	public override function next():Float {
+		if(time > tickCap) {
+			extraTime += time - tickCap;
+			time = tickCap;
+		}
+
+		return super.next();
+	}
+
+
+}

--- a/src/echoes/utils/Timestep.hx
+++ b/src/echoes/utils/Timestep.hx
@@ -26,8 +26,15 @@ class Timestep {
 
 
 	var time:Time;
-	
+
 	var nextTimestep:Null<Timestep>;
+
+	/**
+	 * While paused, time cannot be added to a `Timestep`.
+	 * If time was already added, iteration will continue
+	 * as normal.
+	 */
+	public var paused:Bool = false;
 
 	public function new(?nextTimestep:Timestep) {
 		this.nextTimestep = nextTimestep;
@@ -35,10 +42,12 @@ class Timestep {
 	}
 
 	public function advance(time:Float):Void {
-		if(nextTimestep != null) {
-			nextTimestep.advance(time);
-		} else {
-			this.time.left += time;
+		if(!paused) {
+			if(nextTimestep != null) {
+				nextTimestep.advance(time);
+			} else {
+				this.time.left += time;
+			}
 		}
 	}
 


### PR DESCRIPTION
I've chosen to build a game engine using Echoes, which required some additions to the base library.

Abstract entities
---------------------
This is syntactic sugar, designed to help ease object-oriented programmers into the ECS mindset. Using an abstract that wraps `Entity`, you can make it act more like a class:

```haxe
abstract Soldier(Entity) {
    public var position:Point;
    public var sprite:Image;
    public var offense:Offense;
    public var defense:Defense;
    public var hp:HP;
    
    public function new(x:Float, y:Float) {
        this = new Entity();
        position = new Point(x, y);
        sprite = new Image("soldier.png");
        offense = 4;
        defense = 2;
        hp = new HP(10);
    }
}
```

It looks and feels like a class, but it's still an `Entity`. For instance, say the soldier's armor breaks and you update the variables. Macro magic will turn your code into the corresponding `Entity` functions:

```haxe
soldier.defense = null; //soldier.remove(Defense);
soldier.hp.value -= 2; //soldier.get(HP).value -= 2;
soldier.sprite = new Image("soldier_broken_armor.png"); //solder.add(new Image("soldier_broken_armor.png"));
```

Other features:

- Every `Entity` function is forwarded, so you can call `add()` and `remove()` and so on.
- You can "extend" your own abstracts to create more specialized entities. For instance, you could have `abstract Sniper(Soldier)`, `abstract Cavalry(Soldier)`, and `abstract Defender(Soldier)`, each with a different set of components. (The basic `Soldier` components will remain available to all three.)
- You can write getters and setters for all your components. (Though since I have no use for this feature, it's been a while since I tested it.)
- You can write other functions, as normal for an `abstract` type. Most code should of course go in systems, but short convenience functions still have their place.

Typedefs as components
---------------------------------
Consider the `Offense` and `Defense` components above. They take integer values, which can be done using abstracts:

```haxe
abstract Offense(Int) from Int to Int {}
abstract Defense(Int) from Int to Int {}
```

But that feels like too much typing for something so simple. Wouldn't it be nice if Haxe had a built-in feature for this sort of situation? Something easier to read and [less repetitive](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)?

```haxe
typedef Offense = Int;
typedef Defense = Int;
```

So now Echoes recognizes these as individual components.

Timesteps
--------------
Timekeeping is fundamental to games, and kind of complicated. Most code just needs to be run once per frame, but some code needs to be multiple times, based on the number of milliseconds that have passed since last frame. Some customization is needed.

Safeguards are needed too. You usually want a maximum time per frame, in case the operating system goes to sleep. Otherwise, the game might wake up after an hour and try to calculate a full hour's worth of physics.

(I know this feels like feature creep. Echoes is supposed to be simple and lightweight. But the fact of the matter is, as long as Echoes has `@update` functions, it's responsible for this. The only alternative is to fundamentally change - or allow overriding of - `SystemList.__update__()`, which is a terrible idea.)

The `Timestep` class is the least invasive solution I could think of. For more details, see the class itself.